### PR TITLE
Feat: Implement bilingual hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,19 +9,35 @@
 </head>
 <body>
 
-    <header class="hero">
-        <img src="https://uxwing.com/wp-content/themes/uxwing/download/festival-culture-religion/ganesh-chaturthi-icon.png" alt="Ganesha Icon" class="ganesha-icon">
-        <div class="hero-content animate-on-scroll">
-            <p class="greeting">We're getting married!</p>
-            <h1>Shiv &amp; Sudha</h1>
-            <div class="shloka">
+    <section id="ftn-hero_mobile_v1" aria-label="Invitation hero">
+        <div class="ftn-language-toggle">
+            <button id="ftn-lang-en" class="active" aria-pressed="true">EN</button>
+            <span aria-hidden="true">/</span>
+            <button id="ftn-lang-hi" aria-pressed="false">HI</button>
+        </div>
+        <div class="ftn-hero-content">
+            <p class="ftn-sub" lang="en">You are invited to celebrate the wedding of</p>
+            <p class="ftn-sub" lang="hi" style="display: none;">आपको शादी का जश्न मनाने के लिए आमंत्रित किया गया है</p>
+
+            <h1 class="ftn-heading" lang="en">Shiv &amp; Sudha</h1>
+            <h1 class="ftn-heading" lang="hi" style="display: none;">शिव और सुधा</h1>
+
+            <div class="ftn-shloka">
                 <p>वक्रतुण्ड महाकाय सूर्यकोटि समप्रभ।</p>
                 <p>निर्विघ्नं कुरु मे देव सर्वकार्येषु सर्वदा॥</p>
             </div>
-            <p class="date">15 November, 2025</p>
-            <p class="location">Gonda, Uttar Pradesh</p>
+
+            <p class="ftn-date-venue">
+                <span lang="en">March 15, 2026 &bull; Ramada Palace, Varanasi</span>
+                <span lang="hi" style="display: none;">१५ मार्च, २०२६ &bull; रमादा पैलेस, वाराणसी</span>
+            </p>
+
+            <button id="ftn-hero-rsvp-btn" class="ftn-btn">
+                <span lang="en">RSVP</span>
+                <span lang="hi" style="display: none;">उत्तर दें</span>
+            </button>
         </div>
-    </header>
+    </section>
 
     <section class="details animate-on-scroll">
         <h2>The Auspicious Occasions</h2>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // --- Countdown Timer ---
-// Set the date for the wedding: Nov 15, 2025, at 8:00 PM (20:00:00)
-const weddingDate = new Date("Nov 15, 2025 20:00:00").getTime();
+// Set the date for the wedding: March 15, 2026, at 8:00 PM (20:00:00)
+const weddingDate = new Date("March 15, 2026 20:00:00").getTime();
 
 const countdownFunction = setInterval(function() {
     const now = new Date().getTime();
@@ -115,4 +115,55 @@ document.addEventListener('DOMContentLoaded', () => {
     if (haldiBtn) haldiBtn.href = createGoogleCalendarLink(events.haldi);
     if (mehendiBtn) mehendiBtn.href = createGoogleCalendarLink(events.mehendi);
     if (vivahBtn) vivahBtn.href = createGoogleCalendarLink(events.vivah);
+});
+
+
+// --- Fine-tuned Hero Section Interactivity ---
+document.addEventListener('DOMContentLoaded', () => {
+    // RSVP button smooth scroll
+    const heroRsvpBtn = document.getElementById('ftn-hero-rsvp-btn');
+    const rsvpSection = document.querySelector('.rsvp');
+
+    if (heroRsvpBtn && rsvpSection) {
+        heroRsvpBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            rsvpSection.scrollIntoView({ behavior: 'smooth' });
+        });
+    }
+
+    // Language toggle functionality
+    const langEnBtn = document.getElementById('ftn-lang-en');
+    const langHiBtn = document.getElementById('ftn-lang-hi');
+    const translatableElements = document.querySelectorAll('#ftn-hero_mobile_v1 [lang]');
+
+    const setLanguage = (lang) => {
+        translatableElements.forEach(el => {
+            el.style.display = el.getAttribute('lang') === lang ? '' : 'none';
+        });
+
+        // Update button states
+        if (lang === 'en') {
+            langEnBtn.classList.add('active');
+            langEnBtn.setAttribute('aria-pressed', 'true');
+            langHiBtn.classList.remove('active');
+            langHiBtn.setAttribute('aria-pressed', 'false');
+        } else {
+            langHiBtn.classList.add('active');
+            langHiBtn.setAttribute('aria-pressed', 'true');
+            langEnBtn.classList.remove('active');
+            langEnBtn.setAttribute('aria-pressed', 'false');
+        }
+    };
+
+    if (langEnBtn && langHiBtn) {
+        langEnBtn.addEventListener('click', () => setLanguage('en'));
+        langHiBtn.addEventListener('click', () => setLanguage('hi'));
+
+        // Set initial language based on which button is active
+        if(langHiBtn.classList.contains('active')) {
+            setLanguage('hi');
+        } else {
+            setLanguage('en');
+        }
+    }
 });

--- a/style.css
+++ b/style.css
@@ -318,8 +318,114 @@ footer {
     transform: translateY(0);
 }
 
+/* --- Fine-tuned Hero Section --- */
+#ftn-hero_mobile_v1 {
+    background: linear-gradient(160deg, #6b1426, #0b1220);
+    color: #fff9f0;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 60px 20px;
+    position: relative;
+    font-family: 'Montserrat', sans-serif;
+}
+
+.ftn-language-toggle {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 4px;
+}
+
+.ftn-language-toggle button {
+    background: none;
+    border: none;
+    color: #fff9f0;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 6px 12px;
+    cursor: pointer;
+    border-radius: 16px;
+    transition: background-color 0.3s;
+}
+
+.ftn-language-toggle button.active {
+    background-color: #d9b44a;
+    color: #0b1220;
+}
+
+.ftn-language-toggle span {
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.ftn-hero-content .ftn-sub {
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+    color: #d9b44a;
+}
+
+.ftn-hero-content .ftn-heading {
+    font-family: 'Playfair Display', serif;
+    font-size: 3rem; /* Mobile first */
+    color: #ffffff;
+    margin: 0 0 1rem 0;
+    text-shadow: 2px 2px 8px rgba(0,0,0,0.5);
+    animation: none; /* Override global h1 animation */
+    opacity: 1; /* Ensure it's visible */
+}
+
+.ftn-shloka {
+    font-size: 1.1rem;
+    font-style: italic;
+    margin: 1.5rem auto;
+    line-height: 1.7;
+    max-width: 550px;
+    color: rgba(255, 249, 240, 0.8);
+}
+
+.ftn-shloka p {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.ftn-date-venue {
+    font-size: 1.2rem;
+    margin: 1rem 0 2rem 0;
+}
+
+.ftn-btn {
+    min-height: 44px;
+    padding: 10px 35px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #0b1220;
+    background: #d9b44a;
+    border: 2px solid #d9b44a;
+    border-radius: 999px; /* Pill-shaped */
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.3s;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.ftn-btn:hover {
+    background-color: transparent;
+    color: #d9b44a;
+    transform: scale(1.05);
+}
+
+
 /* --- Responsive Design --- */
 @media (max-width: 768px) {
+    #ftn-hero_mobile_v1 .ftn-heading {
+        font-size: 2.8rem;
+    }
+
     h1 {
         font-size: 3.5rem;
     }


### PR DESCRIPTION
This commit introduces a new, fine-tuned hero section for the wedding invitation website, replacing the previous version. The new section is designed to be mobile-first and is fully bilingual, supporting both English and Hindi.

Key changes include:
- **index.html**: Replaced the old hero section with a new, accessible, and bilingual structure.
- **style.css**: Added isolated, mobile-first styles for the new hero section, following the specified design guidelines (maroon/gold theme, pill-shaped buttons).
- **script.js**: Updated the countdown timer with the new wedding date and added JavaScript for a language toggle and a smooth-scrolling RSVP button.

The implementation follows the detailed instructions provided, ensuring that no existing site structure was altered and all new elements are properly namespaced.