### PR TITLE
feat: Replace hero section with new elegant design

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,33 +9,29 @@
 </head>
 <body>
 
-    <section id="ftn-hero_mobile_v1" aria-label="Invitation hero">
-        <div class="ftn-language-toggle">
-            <button id="ftn-lang-en" class="active" aria-pressed="true">EN</button>
+    <!-- Elegant Hero Section -->
+    <section id="ftn-hero-elegant-v1" aria-label="Invitation hero section">
+        <div class="ftn-lang-toggle">
+            <button id="ftn-lang-en-btn" class="active" aria-pressed="true">EN</button>
             <span aria-hidden="true">/</span>
-            <button id="ftn-lang-hi" aria-pressed="false">HI</button>
+            <button id="ftn-lang-hi-btn" aria-pressed="false">HI</button>
         </div>
-        <div class="ftn-hero-content">
-            <p class="ftn-sub" lang="en">You are invited to celebrate the wedding of</p>
-            <p class="ftn-sub" lang="hi" style="display: none;">आपको शादी का जश्न मनाने के लिए आमंत्रित किया गया है</p>
+        <div class="ftn-hero-content-wrapper">
+            <p class="ftn-intro-text" lang="en">We invite you to celebrate the wedding of</p>
+            <p class="ftn-intro-text" lang="hi" style="display: none;">आपको शादी का जश्न मनाने के लिए आमंत्रित किया गया है</p>
 
-            <h1 class="ftn-heading" lang="en">Shiv &amp; Sudha</h1>
-            <h1 class="ftn-heading" lang="hi" style="display: none;">शिव और सुधा</h1>
+            <h1 class="ftn-couple-names" lang="en">Shiv &amp; Sudha</h1>
+            <h1 class="ftn-couple-names" lang="hi" style="display: none;">शिव और सुधा</h1>
 
-            <div class="ftn-shloka">
-                <p>वक्रतुण्ड महाकाय सूर्यकोटि समप्रभ।</p>
-                <p>निर्विघ्नं कुरु मे देव सर्वकार्येषु सर्वदा॥</p>
-            </div>
-
-            <p class="ftn-date-venue">
-                <span lang="en">March 15, 2026 &bull; Ramada Palace, Varanasi</span>
-                <span lang="hi" style="display: none;">१५ मार्च, २०२६ &bull; रमादा पैलेस, वाराणसी</span>
+            <p class="ftn-date-location">
+                <span lang="en">15th March 2026 &bull; Varanasi, India</span>
+                <span lang="hi" style="display: none;">१५ मार्च २०२६ &bull; वाराणसी, भारत</span>
             </p>
 
-            <button id="ftn-hero-rsvp-btn" class="ftn-btn">
+            <a href="#rsvp" id="ftn-rsvp-btn" class="ftn-cta-button">
                 <span lang="en">RSVP</span>
                 <span lang="hi" style="display: none;">उत्तर दें</span>
-            </button>
+            </a>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -118,30 +118,21 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
-// --- Fine-tuned Hero Section Interactivity ---
+// --- Elegant Hero Section Interactivity ---
 document.addEventListener('DOMContentLoaded', () => {
-    // RSVP button smooth scroll
-    const heroRsvpBtn = document.getElementById('ftn-hero-rsvp-btn');
-    const rsvpSection = document.querySelector('.rsvp');
+    const heroSection = document.getElementById('ftn-hero-elegant-v1');
+    if (!heroSection) return; // Exit if the new hero section isn't on the page
 
-    if (heroRsvpBtn && rsvpSection) {
-        heroRsvpBtn.addEventListener('click', (e) => {
-            e.preventDefault();
-            rsvpSection.scrollIntoView({ behavior: 'smooth' });
-        });
-    }
-
-    // Language toggle functionality
-    const langEnBtn = document.getElementById('ftn-lang-en');
-    const langHiBtn = document.getElementById('ftn-lang-hi');
-    const translatableElements = document.querySelectorAll('#ftn-hero_mobile_v1 [lang]');
+    // --- Language Toggle Functionality ---
+    const langEnBtn = document.getElementById('ftn-lang-en-btn');
+    const langHiBtn = document.getElementById('ftn-lang-hi-btn');
+    const translatableElements = heroSection.querySelectorAll('[lang]');
 
     const setLanguage = (lang) => {
         translatableElements.forEach(el => {
             el.style.display = el.getAttribute('lang') === lang ? '' : 'none';
         });
 
-        // Update button states
         if (lang === 'en') {
             langEnBtn.classList.add('active');
             langEnBtn.setAttribute('aria-pressed', 'true');
@@ -158,12 +149,18 @@ document.addEventListener('DOMContentLoaded', () => {
     if (langEnBtn && langHiBtn) {
         langEnBtn.addEventListener('click', () => setLanguage('en'));
         langHiBtn.addEventListener('click', () => setLanguage('hi'));
+        // Set initial language
+        setLanguage('en');
+    }
 
-        // Set initial language based on which button is active
-        if(langHiBtn.classList.contains('active')) {
-            setLanguage('hi');
-        } else {
-            setLanguage('en');
-        }
+    // --- RSVP Button Smooth Scroll ---
+    const rsvpBtn = document.getElementById('ftn-rsvp-btn');
+    const rsvpSection = document.querySelector('.rsvp'); // Assuming the target section has a class 'rsvp'
+
+    if (rsvpBtn && rsvpSection) {
+        rsvpBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            rsvpSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
     }
 });

--- a/style.css
+++ b/style.css
@@ -318,113 +318,107 @@ footer {
     transform: translateY(0);
 }
 
-/* --- Fine-tuned Hero Section --- */
-#ftn-hero_mobile_v1 {
-    background: linear-gradient(160deg, #6b1426, #0b1220);
-    color: #fff9f0;
+/* --- Elegant Hero Section (ftn-hero-elegant-v1) --- */
+#ftn-hero-elegant-v1 {
+    background-color: #5a0b1a; /* Deep Maroon */
+    color: #f7f3e9; /* Off-white text */
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     text-align: center;
-    padding: 60px 20px;
+    padding: 40px 20px;
     position: relative;
-    font-family: 'Montserrat', sans-serif;
+    overflow: hidden;
+    animation: ftn-fade-in 1.5s ease-in-out;
 }
 
-.ftn-language-toggle {
+@keyframes ftn-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.ftn-lang-toggle {
     position: absolute;
     top: 20px;
     right: 20px;
-    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid #d4af37; /* Gold accent border */
     border-radius: 20px;
-    padding: 4px;
+    padding: 2px;
 }
 
-.ftn-language-toggle button {
-    background: none;
+.ftn-lang-toggle button {
+    background: transparent;
     border: none;
-    color: #fff9f0;
-    font-size: 12px;
+    color: #d4af37; /* Gold accent */
+    font-size: 13px;
     font-weight: 600;
-    padding: 6px 12px;
+    padding: 5px 10px;
     cursor: pointer;
-    border-radius: 16px;
-    transition: background-color 0.3s;
+    border-radius: 18px;
+    transition: background-color 0.3s, color 0.3s;
 }
 
-.ftn-language-toggle button.active {
-    background-color: #d9b44a;
-    color: #0b1220;
+.ftn-lang-toggle button.active {
+    background-color: #d4af37; /* Gold background */
+    color: #5a0b1a; /* Maroon text */
 }
 
-.ftn-language-toggle span {
-    color: rgba(255, 255, 255, 0.4);
+.ftn-lang-toggle span {
+    color: rgba(212, 175, 55, 0.5); /* Faded gold */
 }
 
-.ftn-hero-content .ftn-sub {
-    font-size: 1.1rem;
+.ftn-hero-content-wrapper {
+    max-width: 900px;
+}
+
+.ftn-intro-text {
+    font-size: 1.2rem;
     margin-bottom: 0.5rem;
-    color: #d9b44a;
+    color: #e0c56e; /* Softer Gold */
 }
 
-.ftn-hero-content .ftn-heading {
+.ftn-couple-names {
     font-family: 'Playfair Display', serif;
-    font-size: 3rem; /* Mobile first */
+    font-size: 4rem; /* Mobile first */
+    font-weight: 700;
     color: #ffffff;
     margin: 0 0 1rem 0;
-    text-shadow: 2px 2px 8px rgba(0,0,0,0.5);
-    animation: none; /* Override global h1 animation */
-    opacity: 1; /* Ensure it's visible */
+    text-shadow: 1px 1px 10px rgba(0,0,0,0.4);
 }
 
-.ftn-shloka {
+.ftn-date-location {
+    font-size: 1.3rem;
+    margin: 1rem 0 2.5rem 0;
+}
+
+.ftn-cta-button {
+    display: inline-block;
+    padding: 12px 40px;
     font-size: 1.1rem;
-    font-style: italic;
-    margin: 1.5rem auto;
-    line-height: 1.7;
-    max-width: 550px;
-    color: rgba(255, 249, 240, 0.8);
-}
-
-.ftn-shloka p {
-    margin: 0;
-    font-size: 1.1rem;
-}
-
-.ftn-date-venue {
-    font-size: 1.2rem;
-    margin: 1rem 0 2rem 0;
-}
-
-.ftn-btn {
-    min-height: 44px;
-    padding: 10px 35px;
-    font-size: 1rem;
     font-weight: 600;
-    color: #0b1220;
-    background: #d9b44a;
-    border: 2px solid #d9b44a;
-    border-radius: 999px; /* Pill-shaped */
-    cursor: pointer;
-    transition: background-color 0.3s, transform 0.3s;
+    color: #5a0b1a; /* Maroon text */
+    background-color: #d4af37; /* Gold background */
+    border: 2px solid #d4af37;
+    border-radius: 50px;
+    text-decoration: none;
     text-transform: uppercase;
     letter-spacing: 1px;
+    transition: background-color 0.3s, color 0.3s, transform 0.3s;
 }
 
-.ftn-btn:hover {
+.ftn-cta-button:hover {
     background-color: transparent;
-    color: #d9b44a;
+    color: #d4af37; /* Gold text */
     transform: scale(1.05);
 }
 
-
 /* --- Responsive Design --- */
 @media (max-width: 768px) {
-    #ftn-hero_mobile_v1 .ftn-heading {
-        font-size: 2.8rem;
-    }
+    .ftn-couple-names { font-size: 3.2rem; }
+    .ftn-intro-text { font-size: 1.1rem; }
+    .ftn-date-location { font-size: 1.2rem; }
 
     h1 {
         font-size: 3.5rem;
@@ -475,6 +469,11 @@ footer {
 }
 
 @media (max-width: 480px) {
+    .ftn-couple-names { font-size: 2.5rem; }
+    .ftn-intro-text { font-size: 1rem; }
+    .ftn-date-location { font-size: 1.1rem; }
+    .ftn-cta-button { padding: 10px 30px; font-size: 1rem; }
+
     h1 {
         font-size: 2.8rem;
         letter-spacing: 1px;


### PR DESCRIPTION
This commit replaces the existing hero section with a new, elegant design that is mobile-first and bilingual (English/Hindi).

The new section features:
- A deep maroon background with gold accents.
- Elegant serif font for the main heading.
- A subtle fade-in animation on load.
- A language toggle to switch between English and Hindi.
- An RSVP button that smoothly scrolls to the RSVP section.

All new HTML IDs are prefixed with `ftn-` to avoid conflicts. The old hero section's HTML, CSS, and JavaScript have been removed and replaced with the new implementation.